### PR TITLE
NaoqiSpeech.cfg: fix for python2/3 compatible codes,

### DIFF
--- a/naoqi_driver_py/cfg/NaoqiSpeech.cfg
+++ b/naoqi_driver_py/cfg/NaoqiSpeech.cfg
@@ -75,7 +75,7 @@ params = {
 
 gen = pg.ParameterGenerator()
 
-for name, options in params.iteritems():
+for name, options in params.items():
     gen.add(
         name,
         options.get("type"),


### PR DESCRIPTION
`for name, options in params.iteritems():` is python2 codes. Use `for name, options in params.items():`  to work both python2 and python3. 

https://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items

this need to pass test at https://github.com/jsk-ros-pkg/jsk_robot/actions/runs/3755199280/jobs/6380063414 (https://github.com/jsk-ros-pkg/jsk_robot/pull/1770 )

@kochigami 
